### PR TITLE
Keep custom filter in datatables until reset

### DIFF
--- a/main.js
+++ b/main.js
@@ -131,12 +131,15 @@ export default function GraphicalFilter(brapi_node,trait_accessor,table_col_acce
         gfilter.root.updateData(gfilter.data);
         gfilter.root.draw();
 
+        // clear the previous custom filter
+        // we only add custom filters here, so this should be safe
+        $.fn.dataTableExt.afnFiltering.pop();
+
         var currentFilter = gfilter.root.getFilter();
         $.fn.dataTableExt.afnFiltering.push(function( _1, _2, dataIndex ){
           return currentFilter(gfilter.data[dataIndex]);
         });
         gfilter.results_table.draw();
-        $.fn.dataTableExt.afnFiltering.pop();
       }
       gfilter.redraw();
     })


### PR DESCRIPTION
custom `dataTableExt.afnFiltering` was being removed immediately after
filtering, which means that any additional filter (or sort) coming from
the datatable itself will clear the custom filters from the graphical
component:

https://user-images.githubusercontent.com/19394293/146993559-9dd8fc99-4d04-419c-826c-a6e7a2b8bd06.mp4

If that was not the intended behavior, this fixes it by moving `$.fn.dataTableExt.afnFiltering.pop()` before `push()`, not only to
keep the filter after the first apply, but also to clear previous filters on `redraw()`

cc @MFlores2021